### PR TITLE
Add OnSceneGUI visualization

### DIFF
--- a/Assets/Scripts/Slime/Editor/SlimeEditor.cs
+++ b/Assets/Scripts/Slime/Editor/SlimeEditor.cs
@@ -10,16 +10,51 @@ public class SlimeEditor : Editor
 	Editor settingsEditor;
 	bool settingsFoldout;
 
-	public override void OnInspectorGUI()
-	{
-		DrawDefaultInspector();
-		Simulation sim = target as Simulation;
+        public override void OnInspectorGUI()
+        {
+                DrawDefaultInspector();
+                Simulation sim = target as Simulation;
 
 		if (sim.settings != null) {
 			DrawSettingsEditor(sim.settings, ref settingsFoldout, ref settingsEditor);
 			EditorPrefs.SetBool (nameof (settingsFoldout), settingsFoldout);
-		}
-	}
+                }
+        }
+
+        void OnSceneGUI () {
+                Simulation sim = target as Simulation;
+                if (sim == null || sim.settings == null) {
+                        return;
+                }
+
+                var meshRenderer = sim.GetComponentInChildren<MeshRenderer>();
+                if (meshRenderer == null) {
+                        return;
+                }
+
+                Transform t = meshRenderer.transform;
+                float width = t.lossyScale.x;
+                float height = t.lossyScale.y;
+
+                using (new Handles.DrawingScope(Matrix4x4.TRS(t.position, t.rotation, Vector3.one))) {
+                        Handles.color = Color.cyan;
+                        Handles.DrawWireCube(Vector3.zero, new Vector3(width, height, 0));
+
+                        float radiusRatio = 0;
+                        if (sim.settings.spawnMode == Simulation.SpawnMode.InwardCircle) {
+                                radiusRatio = 0.5f;
+                        }
+                        else if (sim.settings.spawnMode == Simulation.SpawnMode.RandomCircle) {
+                                radiusRatio = 0.15f;
+                        }
+
+                        if (radiusRatio > 0) {
+                                float radius = height * radiusRatio;
+                                Handles.color = Color.yellow;
+                                Handles.DrawWireDisc(Vector3.zero, Vector3.forward, radius);
+                        }
+                }
+        }
 
 	void DrawSettingsEditor(Object settings, ref bool foldout, ref Editor editor)
 	{


### PR DESCRIPTION
## Summary
- implement a custom `OnSceneGUI` in `SlimeEditor`
- draw simulation bounds and spawn circle based on current spawn mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874bc4eff008320a3177a472cc60e2e