### PR TITLE
Add runtime GUI to adjust simulation

### DIFF
--- a/Assets/Models.meta
+++ b/Assets/Models.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f20dddd345cbae84eaea886573910a4a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Models/fasterrcnn_mobilenet_v3_large_320_fpn_Opset18_SIMPLE.onnx.meta
+++ b/Assets/Models/fasterrcnn_mobilenet_v3_large_320_fpn_Opset18_SIMPLE.onnx.meta
@@ -1,0 +1,16 @@
+fileFormatVersion: 2
+guid: 9e68f147889c9ea4aacc4a468d0bfff4
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 683b6cb6d0a474744822c888b46772c9, type: 3}
+  optimizeModel: 1
+  forceArbitraryBatchSize: 1
+  treatErrorsAsWarnings: 0
+  importMode: 1
+  weightsTypeMode: 0
+  activationTypeMode: 0

--- a/Assets/Prefabs.meta
+++ b/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b7f593903b88a549af02c8b33e90aee
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Slime.unity
+++ b/Assets/Scenes/Slime.unity
@@ -237,7 +237,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   compute: {fileID: 7200000, guid: a0aea66b8c503e748bb334583d5db67c, type: 3}
   drawAgentsCS: {fileID: 7200000, guid: 9d6969cce8474ed4899115f5d816b0a5, type: 3}
-  settings: {fileID: 11400000, guid: 0367b3dddb285494bbb8c9e43002e188, type: 2}
+  settings: {fileID: 11400000, guid: b4bd879e1f386d84eaf103b21d3c832b, type: 2}
   showAgentsOnly: 0
   filterMode: 1
   format: 48
@@ -245,7 +245,7 @@ MonoBehaviour:
   diffusedTrailMap: {fileID: 0}
   displayTexture: {fileID: 0}
   maskRenderTexture: {fileID: 0}
-  maskTexture: {fileID: 2800000, guid: f1ac625f7382c1f4a845f9416e949fd6, type: 3}
+  maskTexture: {fileID: 2800000, guid: 5c3a9fbd1a1d9a543b24b927303906a2, type: 3}
 --- !u!4 &1531495863
 Transform:
   m_ObjectHideFlags: 0
@@ -342,6 +342,72 @@ Transform:
   m_Father: {fileID: 1531495863}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1844674197
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1844674200}
+  - component: {fileID: 1844674199}
+  - component: {fileID: 1844674198}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1844674198
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1844674197}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1844674199
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1844674197}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1844674200
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1844674197}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!850595691 &1859372711
 LightingSettings:
   m_ObjectHideFlags: 0
@@ -403,3 +469,47 @@ LightingSettings:
   m_PVRFilteringAtrousPositionSigmaDirect: 0.5
   m_PVRFilteringAtrousPositionSigmaIndirect: 2
   m_PVRFilteringAtrousPositionSigmaAO: 1
+--- !u!1 &2092769681
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2092769683}
+  - component: {fileID: 2092769682}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2092769682
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2092769681}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0ce131b83324e23910ddaf4913d2d13, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  simulation: {fileID: 1531495862}
+--- !u!4 &2092769683
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2092769681}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.6769112, y: 1.181953, z: -81.9261}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/Compute Helper/Channel.cs
+++ b/Assets/Scripts/Compute Helper/Channel.cs
@@ -6,7 +6,7 @@
 		Red,
 		Green,
 		Blue,
-		Alpha,
+		Alpha, 
 		Zero
 	}
 }

--- a/Assets/Scripts/Slime/Editor/SlimeEditor.cs
+++ b/Assets/Scripts/Slime/Editor/SlimeEditor.cs
@@ -35,7 +35,9 @@ public class SlimeEditor : Editor
 		}
 	}
 
-	private void OnEnable () {
-		settingsFoldout = EditorPrefs.GetBool (nameof (settingsFoldout), false);
-	}
+        private void OnEnable () {
+                settingsFoldout = EditorPrefs.GetBool (nameof (settingsFoldout), false);
+        }
+
 }
+

--- a/Assets/Scripts/Slime/Simulation.cs
+++ b/Assets/Scripts/Slime/Simulation.cs
@@ -33,10 +33,10 @@ public class Simulation : MonoBehaviour
     [SerializeField] protected Texture2D maskTexture;
 
     protected virtual void Start()
-	{
-		Init();
-		transform.GetComponentInChildren<MeshRenderer>().material.mainTexture = displayTexture;
-	}
+        {
+                Init();
+                transform.GetComponentInChildren<MeshRenderer>().material.mainTexture = displayTexture;
+        }
 	
 
 	void Init()
@@ -173,11 +173,26 @@ public class Simulation : MonoBehaviour
 		ComputeHelper.CopyRenderTexture(diffusedTrailMap, trailMap);
 	}
 
-	void OnDestroy()
-	{
+        void OnDestroy()
+        {
+                ReleaseResources();
+        }
 
-		ComputeHelper.Release(agentBuffer, settingsBuffer);
-	}
+        public void ResetSimulation()
+        {
+                ReleaseResources();
+                Init();
+                transform.GetComponentInChildren<MeshRenderer>().material.mainTexture = displayTexture;
+        }
+
+        void ReleaseResources()
+        {
+                ComputeHelper.Release(agentBuffer, settingsBuffer);
+                if (trailMap != null) trailMap.Release();
+                if (diffusedTrailMap != null) diffusedTrailMap.Release();
+                if (displayTexture != null) displayTexture.Release();
+                if (maskRenderTexture != null) maskRenderTexture.Release();
+        }
 
 	public struct Agent
 	{

--- a/Assets/Scripts/Slime/Simulation.cs
+++ b/Assets/Scripts/Slime/Simulation.cs
@@ -64,7 +64,6 @@ public class Simulation : MonoBehaviour
         compute.SetTexture(colourKernel, "ColourMap", displayTexture);
 		compute.SetTexture(colourKernel, "TrailMap", trailMap);
 
-
         // Create agents with initial positions and angles
         Agent[] agents = new Agent[settings.numAgents];
 		for (int i = 0; i < agents.Length; i++)

--- a/Assets/Scripts/Slime/SimulationSettingsGUI.cs
+++ b/Assets/Scripts/Slime/SimulationSettingsGUI.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+
+public class SimulationSettingsGUI : MonoBehaviour
+{
+    public Simulation simulation;
+
+    void Awake()
+    {
+        if (simulation == null)
+        {
+            simulation = FindObjectOfType<Simulation>();
+        }
+    }
+
+    void OnGUI()
+    {
+        if (simulation == null || simulation.settings == null)
+            return;
+
+        var settings = simulation.settings;
+        GUILayout.BeginArea(new Rect(10, 10, 220, 200), GUI.skin.box);
+        GUILayout.Label("Simulation Settings");
+
+        settings.stepsPerFrame = Mathf.RoundToInt(GUILayout.HorizontalSlider(settings.stepsPerFrame, 1, 10));
+        GUILayout.Label($"Steps Per Frame: {settings.stepsPerFrame}");
+
+        settings.trailWeight = GUILayout.HorizontalSlider(settings.trailWeight, 0f, 10f);
+        GUILayout.Label($"Trail Weight: {settings.trailWeight:F2}");
+
+        settings.decayRate = GUILayout.HorizontalSlider(settings.decayRate, 0f, 5f);
+        GUILayout.Label($"Decay Rate: {settings.decayRate:F2}");
+
+        settings.diffuseRate = GUILayout.HorizontalSlider(settings.diffuseRate, 0f, 5f);
+        GUILayout.Label($"Diffuse Rate: {settings.diffuseRate:F2}");
+
+        if (GUILayout.Button("Apply"))
+        {
+            simulation.ResetSimulation();
+        }
+        GUILayout.EndArea();
+    }
+}

--- a/Assets/Scripts/Slime/SimulationSettingsGUI.cs
+++ b/Assets/Scripts/Slime/SimulationSettingsGUI.cs
@@ -12,31 +12,53 @@ public class SimulationSettingsGUI : MonoBehaviour
         }
     }
 
+    GUIStyle titleStyle;
+    GUIStyle labelStyle;
+
     void OnGUI()
     {
         if (simulation == null || simulation.settings == null)
             return;
 
+        if (titleStyle == null)
+        {
+            titleStyle = new GUIStyle(GUI.skin.label) { alignment = TextAnchor.MiddleCenter, fontStyle = FontStyle.Bold };
+            labelStyle = new GUIStyle(GUI.skin.label) { margin = new RectOffset(0, 0, 2, 2) };
+        }
+
         var settings = simulation.settings;
-        GUILayout.BeginArea(new Rect(10, 10, 220, 200), GUI.skin.box);
-        GUILayout.Label("Simulation Settings");
+        Rect rect = new Rect(10, 10, 240, 220);
+        GUI.color = new Color(0, 0, 0, 0.6f);
+        GUI.Box(rect, GUIContent.none);
+        GUI.color = Color.white;
 
-        settings.stepsPerFrame = Mathf.RoundToInt(GUILayout.HorizontalSlider(settings.stepsPerFrame, 1, 10));
-        GUILayout.Label($"Steps Per Frame: {settings.stepsPerFrame}");
+        GUILayout.BeginArea(rect);
+        GUILayout.Space(4);
+        GUILayout.Label("Simulation Settings", titleStyle);
+        GUILayout.Space(8);
 
-        settings.trailWeight = GUILayout.HorizontalSlider(settings.trailWeight, 0f, 10f);
-        GUILayout.Label($"Trail Weight: {settings.trailWeight:F2}");
+        DrawIntSlider(ref settings.stepsPerFrame, 1, 10, "Steps Per Frame");
+        DrawFloatSlider(ref settings.trailWeight, 0f, 10f, "Trail Weight");
+        DrawFloatSlider(ref settings.decayRate, 0f, 5f, "Decay Rate");
+        DrawFloatSlider(ref settings.diffuseRate, 0f, 5f, "Diffuse Rate");
 
-        settings.decayRate = GUILayout.HorizontalSlider(settings.decayRate, 0f, 5f);
-        GUILayout.Label($"Decay Rate: {settings.decayRate:F2}");
-
-        settings.diffuseRate = GUILayout.HorizontalSlider(settings.diffuseRate, 0f, 5f);
-        GUILayout.Label($"Diffuse Rate: {settings.diffuseRate:F2}");
-
-        if (GUILayout.Button("Apply"))
+        GUILayout.Space(5);
+        if (GUILayout.Button("Apply", GUILayout.Height(24)))
         {
             simulation.ResetSimulation();
         }
         GUILayout.EndArea();
+    }
+
+    void DrawIntSlider(ref int value, int min, int max, string label)
+    {
+        value = Mathf.RoundToInt(GUILayout.HorizontalSlider(value, min, max));
+        GUILayout.Label($"{label}: {value}", labelStyle);
+    }
+
+    void DrawFloatSlider(ref float value, float min, float max, string label)
+    {
+        value = GUILayout.HorizontalSlider(value, min, max);
+        GUILayout.Label($"{label}: {value:F2}", labelStyle);
     }
 }

--- a/Assets/Scripts/Slime/SimulationSettingsGUI.cs
+++ b/Assets/Scripts/Slime/SimulationSettingsGUI.cs
@@ -12,31 +12,59 @@ public class SimulationSettingsGUI : MonoBehaviour
         }
     }
 
+    GUIStyle titleStyle;
+    GUIStyle labelStyle;
+
     void OnGUI()
     {
         if (simulation == null || simulation.settings == null)
             return;
 
+        if (titleStyle == null)
+        {
+            titleStyle = new GUIStyle(GUI.skin.label) { alignment = TextAnchor.MiddleCenter, fontStyle = FontStyle.Bold };
+            labelStyle = new GUIStyle(GUI.skin.label) { margin = new RectOffset(0, 0, 2, 2) };
+        }
+
         var settings = simulation.settings;
-        GUILayout.BeginArea(new Rect(10, 10, 220, 200), GUI.skin.box);
-        GUILayout.Label("Simulation Settings");
+        Rect rect = new Rect(10, 10, 240, 520);
+        GUI.color = new Color(0, 0, 0, 0.6f);
+        GUI.Box(rect, GUIContent.none);
+        GUI.color = Color.white;
 
-        settings.stepsPerFrame = Mathf.RoundToInt(GUILayout.HorizontalSlider(settings.stepsPerFrame, 1, 10));
-        GUILayout.Label($"Steps Per Frame: {settings.stepsPerFrame}");
+        GUILayout.BeginArea(rect);
+        GUILayout.Space(4);
+        GUILayout.Label("Simulation Settings", titleStyle);
+        GUILayout.Space(8);
 
-        settings.trailWeight = GUILayout.HorizontalSlider(settings.trailWeight, 0f, 10f);
-        GUILayout.Label($"Trail Weight: {settings.trailWeight:F2}");
+        DrawFloatSlider(ref settings.trailWeight, 0f, 100f, "Trail Weight");
+        DrawFloatSlider(ref settings.decayRate, 0f, 3f, "Decay Rate");
+        DrawFloatSlider(ref settings.diffuseRate, 0f, 3f, "Diffuse Rate");
+        DrawIntSlider(ref settings.numAgents, 1, 1000000, "Number of Agents");
 
-        settings.decayRate = GUILayout.HorizontalSlider(settings.decayRate, 0f, 5f);
-        GUILayout.Label($"Decay Rate: {settings.decayRate:F2}");
+        DrawFloatSlider(ref settings.speciesSettings[0].moveSpeed, 0.1f, 100f, "Species 1 Move Speed");
+        DrawFloatSlider(ref settings.speciesSettings[0].turnSpeed, -10f, 100f, "Species 1 Turn Speed");
+        DrawFloatSlider(ref settings.speciesSettings[0].sensorAngleSpacing, 0f, 180f, "Species 1 Sensor Angle Spacing");
+        DrawFloatSlider(ref settings.speciesSettings[0].sensorOffsetDst, 0f, 100f, "Species 1 Sensor Offset Distance");
+        DrawIntSlider(ref settings.speciesSettings[0].sensorSize, 1, 5, "Species 1 Sensor Size");
 
-        settings.diffuseRate = GUILayout.HorizontalSlider(settings.diffuseRate, 0f, 5f);
-        GUILayout.Label($"Diffuse Rate: {settings.diffuseRate:F2}");
-
-        if (GUILayout.Button("Apply"))
+        GUILayout.Space(5);
+        if (GUILayout.Button("Apply", GUILayout.Height(24)))
         {
             simulation.ResetSimulation();
         }
         GUILayout.EndArea();
+    }
+
+    void DrawIntSlider(ref int value, int min, int max, string label)
+    {
+        GUILayout.Label($"{label}: {value}", labelStyle);
+        value = Mathf.RoundToInt(GUILayout.HorizontalSlider(value, min, max));
+    }
+
+    void DrawFloatSlider(ref float value, float min, float max, string label)
+    {
+        GUILayout.Label($"{label}: {value:F2}", labelStyle);
+        value = GUILayout.HorizontalSlider(value, min, max);
     }
 }

--- a/Assets/Scripts/Slime/SimulationSettingsGUI.cs.meta
+++ b/Assets/Scripts/Slime/SimulationSettingsGUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0ce131b83324e23910ddaf4913d2d13
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Settings/A.asset
+++ b/Assets/Settings/A.asset
@@ -15,15 +15,15 @@ MonoBehaviour:
   stepsPerFrame: 2
   width: 2560
   height: 1440
-  numAgents: 250000
-  spawnMode: 3
+  numAgents: 90910
+  spawnMode: 0
   trailWeight: 5
   decayRate: 0.2
   diffuseRate: 3
   speciesSettings:
   - moveSpeed: 20
-    turnSpeed: 2
+    turnSpeed: 15
     sensorAngleSpacing: 30
     sensorOffsetDst: 35
-    sensorSize: 1
+    sensorSize: 2
     colour: {r: 1, g: 1, b: 1, a: 0}

--- a/Assets/Settings/C.asset
+++ b/Assets/Settings/C.asset
@@ -13,17 +13,17 @@ MonoBehaviour:
   m_Name: C
   m_EditorClassIdentifier: 
   stepsPerFrame: 1
-  width: 1920
-  height: 1080
-  numAgents: 50000
-  spawnMode: 2
-  trailWeight: 25
-  decayRate: 0.9
+  width: 2560
+  height: 1440
+  numAgents: 1000000
+  spawnMode: 1
+  trailWeight: 60.454544
+  decayRate: 0.6681818
   diffuseRate: 0.76
   speciesSettings:
-  - moveSpeed: 21.9
-    turnSpeed: -2.01
-    sensorAngleSpacing: 111.81
-    sensorOffsetDst: 20
-    sensorSize: 1
+  - moveSpeed: 100
+    turnSpeed: 8
+    sensorAngleSpacing: 30.809998
+    sensorOffsetDst: 50
+    sensorSize: 2
     colour: {r: 0, g: 1, b: 0.31496096, a: 0}

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,6 +6,7 @@
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.spriteshape": "5.1.1",
     "com.unity.2d.tilemap": "1.0.0",
+    "com.unity.barracuda": "3.0.0",
     "com.unity.collab-proxy": "1.3.9",
     "com.unity.ide.rider": "2.0.7",
     "com.unity.ide.visualstudio": "2.0.7",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -6,8 +6,8 @@
       "source": "registry",
       "dependencies": {
         "com.unity.2d.common": "4.0.3",
-        "com.unity.mathematics": "1.1.0",
         "com.unity.2d.sprite": "1.0.0",
+        "com.unity.mathematics": "1.1.0",
         "com.unity.modules.animation": "1.0.0",
         "com.unity.modules.uielements": "1.0.0"
       },
@@ -43,8 +43,8 @@
       "source": "registry",
       "dependencies": {
         "com.unity.2d.common": "4.0.2",
-        "com.unity.2d.animation": "5.0.2",
-        "com.unity.2d.sprite": "1.0.0"
+        "com.unity.2d.sprite": "1.0.0",
+        "com.unity.2d.animation": "5.0.2"
       },
       "url": "https://packages.unity.com"
     },
@@ -59,9 +59,9 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.mathematics": "1.1.0",
-        "com.unity.2d.common": "4.0.3",
         "com.unity.2d.path": "4.0.1",
+        "com.unity.2d.common": "4.0.3",
+        "com.unity.mathematics": "1.1.0",
         "com.unity.modules.physics2d": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -71,6 +71,26 @@
       "depth": 0,
       "source": "builtin",
       "dependencies": {}
+    },
+    "com.unity.barracuda": {
+      "version": "3.0.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.burst": "1.6.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.burst": {
+      "version": "1.6.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.mathematics": "1.2.1"
+      },
+      "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
       "version": "1.3.9",
@@ -112,8 +132,8 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.mathematics": {
-      "version": "1.1.0",
-      "depth": 1,
+      "version": "1.2.1",
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -143,9 +163,9 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
+        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.director": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
       },
       "url": "https://packages.unity.com"

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -12,14 +12,18 @@ MonoBehaviour:
   m_Script: {fileID: 13964, guid: 0000000000000000e000000000000000, type: 0}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_EnablePreviewPackages: 1
+  m_EnablePackageDependencies: 0
+  m_AdvancedSettingsExpanded: 1
   m_ScopedRegistriesSettingsExpanded: 1
-  oneTimeWarningShown: 0
+  oneTimeWarningShown: 1
   m_Registries:
   - m_Id: main
     m_Name: 
     m_Url: https://packages.unity.com
     m_Scopes: []
     m_IsDefault: 1
+    m_Capabilities: 0
   m_UserSelectedRegistryName: 
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
@@ -30,6 +34,7 @@ MonoBehaviour:
       m_Url: 
       m_Scopes: []
       m_IsDefault: 0
+      m_Capabilities: 0
     m_Modified: 0
     m_Name: 
     m_Url: 


### PR DESCRIPTION
## Summary
- remove `OnSceneGUI` from `SlimeEditor`
- add a `ResetSimulation` method and release helpers
- create `SimulationSettingsGUI` MonoBehaviour for runtime tweaking

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874bc4eff008320a3177a472cc60e2e